### PR TITLE
Use acts_as_list position_column method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,7 +130,7 @@ GEM
       mini_portile (~> 0.6.0)
     parser (2.2.2.6)
       ast (>= 1.1, < 3.0)
-    phantomjs (1.9.8.0)
+    phantomjs (2.1.1.0)
     poltergeist (1.6.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -244,4 +244,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.10.6
+   1.14.3

--- a/lib/active_admin/sortable_table/handle_column.rb
+++ b/lib/active_admin/sortable_table/handle_column.rb
@@ -38,7 +38,7 @@ module ActiveAdmin
         column '', class: 'activeadmin_sortable_table' do |resource|
           options = defined_options.evaluate(self, resource)
 
-          sort_handle(options, resource.position) + move_to_top_handle(options)
+          sort_handle(options, resource.send(resource.position_column)) + move_to_top_handle(options)
         end
       end
 

--- a/spec/dummy/app/admin/categories.rb
+++ b/spec/dummy/app/admin/categories.rb
@@ -1,13 +1,13 @@
 ActiveAdmin.register Category do
   include ActiveAdmin::SortableTable
-  permit_params :id, :position
-  config.sort_order = 'position_asc'
+  permit_params :id, :number
+  config.sort_order = 'number_asc'
   config.per_page = 3
 
   index do
     handle_column
     id_column
-    column :position
+    column :number
     actions
   end
 end

--- a/spec/dummy/app/models/category.rb
+++ b/spec/dummy/app/models/category.rb
@@ -1,3 +1,3 @@
 class Category < ActiveRecord::Base
-  acts_as_list
+  acts_as_list column: :number
 end

--- a/spec/dummy/db/migrate/20150910072505_create_categories.rb
+++ b/spec/dummy/db/migrate/20150910072505_create_categories.rb
@@ -1,7 +1,7 @@
 class CreateCategories < ActiveRecord::Migration
   def change
     create_table :categories do |t|
-      t.integer :position
+      t.integer :number
     end
   end
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -30,7 +30,7 @@ ActiveRecord::Schema.define(version: 20150910072505) do
 
   create_table "categories", force: :cascade do |t|
     t.string  "name"
-    t.integer "position"
+    t.integer "number"
   end
 
 end

--- a/spec/features/drag_and_drop_spec.rb
+++ b/spec/features/drag_and_drop_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ActiveAdmin::SortableTable, 'Drag-and-Drop', type: :feature, js: 
   end
 
   def ordered_ids
-    Category.order(:position).pluck(:id)
+    Category.order(:number).pluck(:id)
   end
 
   context 'first page' do
@@ -16,15 +16,15 @@ RSpec.describe ActiveAdmin::SortableTable, 'Drag-and-Drop', type: :feature, js: 
       visit admin_categories_path
 
       expect(visible_ids).to eq([1, 2, 3])
-      expect(visible_positions).to eq([1, 2, 3])
+      expect(visible_numbers).to eq([1, 2, 3])
     end
 
     context 'move element up' do
-      it 'to the top position' do
+      it 'to the top number' do
         move_up(3, by: 2)
 
         expect(visible_ids).to eq([3, 1, 2])
-        expect(visible_positions).to eq([1, 2, 3])
+        expect(visible_numbers).to eq([1, 2, 3])
         expect(ordered_ids).to eq([3, 1, 2])
       end
 
@@ -32,7 +32,7 @@ RSpec.describe ActiveAdmin::SortableTable, 'Drag-and-Drop', type: :feature, js: 
         move_up(3, by: 1)
 
         expect(visible_ids).to eq([1, 3, 2])
-        expect(visible_positions).to eq([1, 2, 3])
+        expect(visible_numbers).to eq([1, 2, 3])
         expect(ordered_ids).to eq([1, 3, 2])
       end
     end
@@ -42,7 +42,7 @@ RSpec.describe ActiveAdmin::SortableTable, 'Drag-and-Drop', type: :feature, js: 
         move_down(1, by: 2)
 
         expect(visible_ids).to eq([2, 3, 1])
-        expect(visible_positions).to eq([1, 2, 3])
+        expect(visible_numbers).to eq([1, 2, 3])
         expect(ordered_ids).to eq([2, 3, 1])
       end
 
@@ -50,7 +50,7 @@ RSpec.describe ActiveAdmin::SortableTable, 'Drag-and-Drop', type: :feature, js: 
         move_down(2, by: 1)
 
         expect(visible_ids).to eq([1, 3, 2])
-        expect(visible_positions).to eq([1, 2, 3])
+        expect(visible_numbers).to eq([1, 2, 3])
         expect(ordered_ids).to eq([1, 3, 2])
       end
     end
@@ -59,7 +59,7 @@ RSpec.describe ActiveAdmin::SortableTable, 'Drag-and-Drop', type: :feature, js: 
       move_up(3, by: 2, use_handle: false)
 
       expect(visible_ids).to eq([1, 2, 3])
-      expect(visible_positions).to eq([1, 2, 3])
+      expect(visible_numbers).to eq([1, 2, 3])
       expect(ordered_ids).to eq([1, 2, 3])
     end
   end
@@ -77,7 +77,7 @@ RSpec.describe ActiveAdmin::SortableTable, 'Drag-and-Drop', type: :feature, js: 
       visit admin_categories_path(page: 2)
 
       expect(visible_ids).to eq([4, 5, 6])
-      expect(visible_positions).to eq([4, 5, 6])
+      expect(visible_numbers).to eq([4, 5, 6])
     end
 
     context 'move element up' do
@@ -85,7 +85,7 @@ RSpec.describe ActiveAdmin::SortableTable, 'Drag-and-Drop', type: :feature, js: 
         move_up(6, by: 2)
 
         expect(visible_ids).to eq([6, 4, 5])
-        expect(visible_positions).to eq([4, 5, 6])
+        expect(visible_numbers).to eq([4, 5, 6])
         expect(ordered_ids).to eq([1, 2, 3, 6, 4, 5])
       end
 
@@ -93,7 +93,7 @@ RSpec.describe ActiveAdmin::SortableTable, 'Drag-and-Drop', type: :feature, js: 
         move_up(6, by: 1)
 
         expect(visible_ids).to eq([4, 6, 5])
-        expect(visible_positions).to eq([4, 5, 6])
+        expect(visible_numbers).to eq([4, 5, 6])
         expect(ordered_ids).to eq([1, 2, 3, 4, 6, 5])
       end
     end
@@ -103,7 +103,7 @@ RSpec.describe ActiveAdmin::SortableTable, 'Drag-and-Drop', type: :feature, js: 
         move_down(4, by: 2)
 
         expect(visible_ids).to eq([5, 6, 4])
-        expect(visible_positions).to eq([4, 5, 6])
+        expect(visible_numbers).to eq([4, 5, 6])
         expect(ordered_ids).to eq([1, 2, 3, 5, 6, 4])
       end
 
@@ -111,7 +111,7 @@ RSpec.describe ActiveAdmin::SortableTable, 'Drag-and-Drop', type: :feature, js: 
         move_down(4, by: 1)
 
         expect(visible_ids).to eq([5, 4, 6])
-        expect(visible_positions).to eq([4, 5, 6])
+        expect(visible_numbers).to eq([4, 5, 6])
         expect(ordered_ids).to eq([1, 2, 3, 5, 4, 6])
       end
     end
@@ -120,7 +120,7 @@ RSpec.describe ActiveAdmin::SortableTable, 'Drag-and-Drop', type: :feature, js: 
       move_down(6, by: 2, use_handle: false)
 
       expect(visible_ids).to eq([4, 5, 6])
-      expect(visible_positions).to eq([4, 5, 6])
+      expect(visible_numbers).to eq([4, 5, 6])
       expect(ordered_ids).to eq([1, 2, 3, 4, 5, 6])
     end
   end
@@ -131,8 +131,8 @@ RSpec.describe ActiveAdmin::SortableTable, 'Drag-and-Drop', type: :feature, js: 
     all('.ui-sortable .col-id').map(&:text).map(&:to_i)
   end
 
-  def visible_positions
-    all('.ui-sortable .col-position').map(&:text).map(&:to_i)
+  def visible_numbers
+    all('.ui-sortable .col-number').map(&:text).map(&:to_i)
   end
 
   def move_up(element_id, by: 1, use_handle: true)

--- a/spec/features/move_to_top_spec.rb
+++ b/spec/features/move_to_top_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ActiveAdmin::SortableTable, 'Move to top', type: :feature, js: tr
   end
 
   def ordered_ids
-    Category.order(:position).pluck(:id)
+    Category.order(:number).pluck(:id)
   end
 
   before do
@@ -17,7 +17,7 @@ RSpec.describe ActiveAdmin::SortableTable, 'Move to top', type: :feature, js: tr
     visit admin_categories_path(page: 2)
 
     expect(visible_ids).to contain_exactly(4)
-    expect(visible_positions).to contain_exactly(4)
+    expect(visible_numbers).to contain_exactly(4)
   end
 
   it 'push element to top by clicking "move to top"' do
@@ -33,7 +33,7 @@ RSpec.describe ActiveAdmin::SortableTable, 'Move to top', type: :feature, js: tr
 
     # I should see pushed elenent on the top
     expect(visible_ids).to eq([4, 1, 2])
-    expect(visible_positions).to eq([1, 2, 3])
+    expect(visible_numbers).to eq([1, 2, 3])
     expect(ordered_ids).to eq([4, 1, 2, 3])
   end
 
@@ -43,8 +43,8 @@ RSpec.describe ActiveAdmin::SortableTable, 'Move to top', type: :feature, js: tr
     all('.ui-sortable .col-id').map(&:text).map(&:to_i)
   end
 
-  def visible_positions
-    all('.ui-sortable .col-position').map(&:text).map(&:to_i)
+  def visible_numbers
+    all('.ui-sortable .col-number').map(&:text).map(&:to_i)
   end
 
   def move_to_top(element_id)


### PR DESCRIPTION
Now it is possible to specify an acts_as_list column other than position:

```ruby
acts_as_list column: :number
```